### PR TITLE
fix tests

### DIFF
--- a/test/terraform/get-modules.bats
+++ b/test/terraform/get-modules.bats
@@ -1,14 +1,16 @@
 load 'lib'
 
 function setup() {
+  exprt TF_CLI_ARGS_init="-get-plugins -backend=false -input=false"
   clean
 }
 
 function teardown() {
   clean
+  unset TF_CLI_ARGS_init
 }
 
 @test "check if terraform modules are valid" {
   skip_unless_terraform
-  run terraform init -get -backend=false -input=false
+  terraform init
 }

--- a/test/terraform/get-modules.bats
+++ b/test/terraform/get-modules.bats
@@ -1,7 +1,7 @@
 load 'lib'
 
 function setup() {
-  exprt TF_CLI_ARGS_init="-get-plugins -backend=false -input=false"
+  export TF_CLI_ARGS_init="-get-plugins -backend=false -input=false"
   clean
 }
 

--- a/test/terraform/get-plugins.bats
+++ b/test/terraform/get-plugins.bats
@@ -6,11 +6,11 @@ function setup() {
 }
 
 function teardown() {
-  unset TF_CLI_ARGS_init
   clean
+  unset TF_CLI_ARGS_init
 }
 
 @test "check if terraform plugins are valid" {
   skip_unless_terraform
-  run terraform init
+  terraform init
 }


### PR DESCRIPTION
## what
* Fix usage error related to `run` command

## why
* When calling `run`, the exit code is stashed in the `status` env and the function returns 0, which in effect squashes the error.
* If we don't need to interpret the result in an unconventional manner, we don't need to call `run` 