### PR TITLE
Fix `terraform-docs`

### DIFF
--- a/test/terraform/input-descriptions.bats
+++ b/test/terraform/input-descriptions.bats
@@ -11,7 +11,7 @@ function teardown() {
 @test "check if terraform inputs have descriptions" {
   skip_unless_terraform
   terraform_docs json . > $TMPFILE
-  run bash -c "jq -rS '.inputs[] | select (.Description == \"\") | .Name + \" is missing a description\"' < $TMPFILE"
+  run bash -c "jq -rS '.inputs[] | select (.description == \"\" or .description == null) | .name + \" is missing a description\"' < $TMPFILE"
   log "$output"
   [ -z "$output" ]
 }

--- a/test/terraform/input-descriptions.bats
+++ b/test/terraform/input-descriptions.bats
@@ -11,7 +11,7 @@ function teardown() {
 @test "check if terraform inputs have descriptions" {
   skip_unless_terraform
   terraform_docs json . > $TMPFILE
-  run bash -c "jq -rS '.Inputs[] | select (.Description == \"\") | .Name + \" is missing a description\"' < $TMPFILE"
+  run bash -c "jq -rS '.inputs[] | select (.Description == \"\") | .Name + \" is missing a description\"' < $TMPFILE"
   log "$output"
   [ -z "$output" ]
 }

--- a/test/terraform/lib.bash
+++ b/test/terraform/lib.bash
@@ -42,18 +42,8 @@ function skip_unless_terraform() {
 }
 
 function terraform_docs() {
-#  local TMP_FILE
   which awk 2>&1 >/dev/null || ( echo "awk not available"; exit 1)
   which terraform 2>&1 >/dev/null || ( echo "terraform not available"; exit 1)
   which terraform-docs 2>&1 >/dev/null || ( echo "terraform-docs not available"; exit 1)
-  terraform-docs $1 $2
-
-#  if [[ "`terraform version | head -1`" =~ 0\.12 ]]; then
-#      TMP_FILE="$(mktemp /tmp/terraform-docs-XXXXXXXXXX.tf)"
-#      awk -f ${BATS_TEST_DIRNAME}/terraform-docs.awk $2/*.tf > ${TMP_FILE}
-#      terraform-docs $1 ${TMP_FILE}
-#      rm -f ${TMP_FILE}
-#  else
-#      terraform-docs $1 $2
-#  fi
+  terraform-docs --no-providers --no-header $1 $2
 }

--- a/test/terraform/lib.bash
+++ b/test/terraform/lib.bash
@@ -42,17 +42,18 @@ function skip_unless_terraform() {
 }
 
 function terraform_docs() {
-  local TMP_FILE
+#  local TMP_FILE
   which awk 2>&1 >/dev/null || ( echo "awk not available"; exit 1)
   which terraform 2>&1 >/dev/null || ( echo "terraform not available"; exit 1)
   which terraform-docs 2>&1 >/dev/null || ( echo "terraform-docs not available"; exit 1)
+  terraform-docs $1 $2
 
-  if [[ "`terraform version | head -1`" =~ 0\.12 ]]; then
-      TMP_FILE="$(mktemp /tmp/terraform-docs-XXXXXXXXXX.tf)"
-      awk -f ${BATS_TEST_DIRNAME}/terraform-docs.awk $2/*.tf > ${TMP_FILE}
-      terraform-docs $1 ${TMP_FILE}
-      rm -f ${TMP_FILE}
-  else
-      terraform-docs $1 $2
-  fi
+#  if [[ "`terraform version | head -1`" =~ 0\.12 ]]; then
+#      TMP_FILE="$(mktemp /tmp/terraform-docs-XXXXXXXXXX.tf)"
+#      awk -f ${BATS_TEST_DIRNAME}/terraform-docs.awk $2/*.tf > ${TMP_FILE}
+#      terraform-docs $1 ${TMP_FILE}
+#      rm -f ${TMP_FILE}
+#  else
+#      terraform-docs $1 $2
+#  fi
 }

--- a/test/terraform/output-descriptions.bats
+++ b/test/terraform/output-descriptions.bats
@@ -11,7 +11,7 @@ function teardown() {
 @test "check if terraform outputs have descriptions" {
   skip_unless_terraform
   terraform_docs json . > $TMPFILE
-  run bash -c "jq -rS '.outputs[] | select (.Description == \"\") | .Name + \" is missing a description\"' < $TMPFILE"
+  run bash -c "jq -rS '.outputs[] | select (.description == \"\" or .description == null) | .name + \" is missing a description\"' < $TMPFILE"
   log "$output"
   [ -z "$output" ]
 }

--- a/test/terraform/output-descriptions.bats
+++ b/test/terraform/output-descriptions.bats
@@ -11,7 +11,7 @@ function teardown() {
 @test "check if terraform outputs have descriptions" {
   skip_unless_terraform
   terraform_docs json . > $TMPFILE
-  run bash -c "jq -rS '.Outputs[] | select (.Description == \"\") | .Name + \" is missing a description\"' < $TMPFILE"
+  run bash -c "jq -rS '.outputs[] | select (.Description == \"\") | .Name + \" is missing a description\"' < $TMPFILE"
   log "$output"
   [ -z "$output" ]
 }


### PR DESCRIPTION
## what
* Fix `terraform-docs`
* Make `terraform-docs` work with TF 0.12

## why
* `terraform-docs` for TF 0.12 introduced many changes
* Add check if terraform descriptions are empty or missing completely

## references
* https://github.com/segmentio/terraform-docs/releases/tag/v0.8.0
