### PR TITLE
Update TF to 0.13.3, update docker build, add auto-release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Use this file to define individuals or teams that are responsible for code in a repository.
+# Read more: <https://help.github.com/articles/about-codeowners/>
+#
+# Order is important: the last matching pattern takes the most precedence
+
+# These owners will be the default owners for everything
+*             @cloudposse/engineering
+
+# Cloud Posse must review any changes to Makefiles
+**/Makefile   @cloudposse/engineering
+**/Makefile.* @cloudposse/engineering
+
+# Cloud Posse must review any changes to GitHub actions
+.github/*     @cloudposse/engineering

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -1,0 +1,40 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'hotfix'
+  default: 'minor'
+
+categories:
+  - title: '🚀 Enhancements'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'hotfix'
+
+change-template: |
+  <details>
+    <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
+
+    $BODY
+  </details>
+
+template: |
+  $CHANGES

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,19 @@
+name: auto-release
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+    # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+      with:
+        publish: true
+        prerelease: false
+        config-name: auto-release.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,25 +1,44 @@
 name: "docker"
 on:
-  push:
-    branches:
-      - master
-  pull_request: 
+  pull_request:
     types: [opened, synchronize, reopened]
   release:
     types:
-      - created
+    - created
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout source code at current commit"
-        uses: actions/checkout@v2
-      - name: "Build and push docker image to DockerHub"
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: ${{ github.repository }}
-          registry: registry-1.docker.io
-          tag_with_ref: true
-          tag_with_sha: true
+    - name: "Checkout source code at current commit"
+      uses: actions/checkout@v2
+    - name: Prepare tags for Docker image
+      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
+      id: prepare
+      run: |
+        TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          VERSION=${GITHUB_REF#refs/tags/}
+        elif [[ $GITHUB_REF == refs/pull/* ]]; then
+          VERSION=pr-${{ github.event.pull_request.number }}-merge
+        fi
+        if [[ -n $VERSION ]]; then
+          TAGS="$TAGS,${{ github.repository }}:${VERSION}"
+        fi
+        if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+          TAGS="$TAGS,${{ github.repository }}:latest"
+        fi
+        echo ::set-output name=tags::${TAGS}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    - name: "Build and push docker image to DockerHub"
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository }}
+        tags: ${{ steps.prepare.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM cloudposse/build-harness:0.37.0
+FROM cloudposse/build-harness:0.44.2
 
-RUN apk add go terraform_0.11@cloudposse terraform_0.12@cloudposse terraform_0.13@cloudposse
+RUN apk add go terraform-0.11@cloudposse terraform-0.12@cloudposse terraform-0.13@cloudposse~=0.13.3
 
 COPY test/ /test/
 


### PR DESCRIPTION
## what

- Update Terraform to 0.13.3 and latest APK packages
- Update build-harness to 0.44.2
- Update docker build to push release label tag
- Add auto-release
- Add CODEOWNERS

## why

- Terraform 0.13.3 has significant bug fixes needed by some modules
- Keep build tools in sync
- Allow people to choose docker image based on release version
- Handle release automatically
- Protect files from uninformed changes