### PR TITLE
bats test fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM cloudposse/build-harness:0.44.2
 
-RUN apk add go terraform-0.11@cloudposse terraform-0.12@cloudposse terraform-0.13@cloudposse~=0.13.3
+RUN apk add go terraform-0.11@cloudposse terraform-0.12@cloudposse terraform-0.13@cloudposse terraform-0.14@cloudposse
 
 COPY test/ /test/
 


### PR DESCRIPTION
## what
* bats test for version pinning fixed to support Terraform Registry notation

## why
* tests failed for Terraform Registry notation modules