### PR TITLE
more logs when terraform-config-inspect not found

### DIFF
--- a/test/terraform/module-pinning.bats
+++ b/test/terraform/module-pinning.bats
@@ -13,6 +13,7 @@ function teardown() {
   skip_unless_terraform
   TCI_BINARY="$(go env GOPATH)/bin/terraform-config-inspect"
   if [[ ! -f $TCI_BINARY ]]; then
+    log "Looking for 'terraform-config-inspect' in $TCI_BINARY"
     log "'terraform-config-inspect' go module required. Check https://github.com/hashicorp/terraform-config-inspect for instructions "
     false
   fi


### PR DESCRIPTION
## what
* more logs added when `terraform-config-inspect` not found

## why
* to be able to figure out why there is no binary in place