### PR TITLE
test requires terraform-config-inspect to be accessible by PATH

### DIFF
--- a/test/terraform/module-pinning.bats
+++ b/test/terraform/module-pinning.bats
@@ -9,14 +9,19 @@ function teardown() {
 :
 }
 
+@test "check if terraform-config-inspect is installed" {
+  skip_unless_terraform
+  if [[ which terraform-config-inspect ]]; then
+    log "'terraform-config-inspect' go module required. Check https://github.com/hashicorp/terraform-config-inspect for instructions "
+    false
+  fi
+}
+
 @test "check if terraform modules are properly pinned" {
   skip_unless_terraform
-  grep -Eo '^\s*source\s*=\s*"(.*?)"' *.tf | cut -d'"' -f2 | sort -u > $TMPFILE
-  if [ -s $TMPFILE ]; then
-    # Verify the modules are pinned to `tags/x.y` or nothing at all (maybe using `version` parameter instead)
-    sed 's/^.*?ref=//' < $TMPFILE | grep -E '^(tags/[0-9]+\.[0-9]+.*|)$'
-  else
-    # If the file is empty, then no modules are being used
-    true
-  fi
+  ## extract all module calls into string with source then | then version (if version parameter exists)
+  terraform-config-inspect --json . | jq '.module_calls[] | "\(.source)|\(.version)"' > $TMPFILE
+  ## check if module url have version in tags or if version pinned with 'version' parameter for Terraform Registry notation
+  ## check diff between terraform-config-inspect output and regexp check to see if all cases are passing checks
+  grep -Eo '^(\".*?tags\/[0-9]+\.[0-9]+.*\|null\"\s?|\".*?\|[0-9]+\.[0-9]+.*\"\s?)+' $TMPFILE | diff $TMPFILE -
 }


### PR DESCRIPTION
## what
* test requires terraform-config-inspect to be accessible by PATH

## why
* to avoid issues with changed GOPATH if lookup for binary by Go module path
