### PR TITLE
Exclude nested modules from provider pinning requirement

### DIFF
--- a/test/terraform/module-pinning.bats
+++ b/test/terraform/module-pinning.bats
@@ -19,8 +19,8 @@ function teardown() {
 
 @test "check if terraform modules are properly pinned" {
   skip_unless_terraform
-  ## extract all module calls into string with source then | then version (if version parameter exists)
-  terraform-config-inspect --json . | jq '.module_calls[] | "\(.source)|\(.version)"' > $TMPFILE
+  ## extract all module calls (except submodules in ./modules/) into string with source then | then version (if version parameter exists)
+  terraform-config-inspect --json . | jq '.module_calls[] | "\(.source)|\(.version)"' | grep -v -F '"./modules' > $TMPFILE
   ## check if module url have version in tags or if version pinned with 'version' parameter for Terraform Registry notation
   ## check diff between terraform-config-inspect output and regexp check to see if all cases are passing checks
   grep -Eo '^(\".*?tags\/[0-9]+\.[0-9]+.*\|null\"\s?|\".*?\|[0-9]+\.[0-9]+.*\"\s?)+' $TMPFILE | diff $TMPFILE -


### PR DESCRIPTION
## what
- Exclude nested modules from provider pinning requirement

## why
- Nested modules should not be specifying providers at all