### PR TITLE
[terraform/module-pinning.bats] Pass if there are no module sources to check

### DIFF
--- a/test/terraform/module-pinning.bats
+++ b/test/terraform/module-pinning.bats
@@ -15,8 +15,9 @@ function teardown() {
 
 @test "check if terraform modules are properly pinned" {
   skip_unless_terraform
-  ## extract all module calls (except submodules in ./modules/) into string with source then | then version (if version parameter exists)
-  terraform-config-inspect --json . | jq '.module_calls[] | "\(.source)|\(.version)"' | grep -v -F '"./modules' > $TMPFILE
+  ## Extract all module calls (except submodules in ./modules/) into string with source then | then version (if version parameter exists)
+  ## Add || true at the end because a pipe failure just means this module has no calls to other modules
+  terraform-config-inspect --json . | jq '.module_calls[] | "\(.source)|\(.version)"' | grep -v -F '"./modules' > $TMPFILE || true
   ## check if module url have version in tags or if version pinned with 'version' parameter for Terraform Registry notation
   ## check diff between terraform-config-inspect output and regexp check to see if all cases are passing checks
   fail=$(grep -vE '^(\".*?tags\/[0-9]+\.[0-9]+.*\|null\"\s?|\".*?\|[0-9]+\.[0-9]+.*\"\s?)+' $TMPFILE) || true


### PR DESCRIPTION
## what
- [terraform/module-pinning.bats] Pass if there are no module sources to check

## why
- Inapplicable tests should detect they are inapplicable and pass, so that we can standardize and run the same tests on all modules