### PR TITLE
Add Terraform 0.15, update build-harness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM cloudposse/build-harness:0.47.0
+FROM cloudposse/build-harness:0.58.0
 
 RUN apk add --update --no-cache go bats vert@cloudposse terraform-config-inspect@cloudposse \
-  terraform-0.11@cloudposse terraform-0.12@cloudposse terraform-0.13@cloudposse terraform-0.14@cloudposse
+  terraform-0.11@cloudposse terraform-0.12@cloudposse terraform-0.13@cloudposse terraform-0.14@cloudposse terraform-0.15@cloudposse
 
 COPY test/ /test/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,10 @@ RUN apk add --update --no-cache go bats vert@cloudposse terraform-config-inspect
 
 COPY test/ /test/
 
+# Our old Makefiles conditionally set TF_CLI_ARGS_init=-get-plugins=true but that
+# became a no-op in Terraform 0.13 and is rejected by Terraform 0.15.
+# We set it here to blank to keep the Makefile from setting it, although this
+# may break Terraform 0.12 in some cases.
+ENV TF_CLI_ARGS_init=""
+
 WORKDIR /


### PR DESCRIPTION
## what
- Add Terraform 0.15
- Update build-harness

# why
- Terratests are run with "current" Terraform, which is 0.15, unless it is missing, in which case it runs with Terraform 0.13, so since Terraform 0.15 has been released, tests have reverted from Terraform 0.14 to 0.13
- Stay in sync
