### PR TITLE
Update aws cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudposse/build-harness:0.58.2
+FROM cloudposse/build-harness:0.58.4
 
 RUN apk add --update --no-cache go bats vert@cloudposse terraform-config-inspect@cloudposse \
   terraform-0.11@cloudposse terraform-0.12@cloudposse terraform-0.13@cloudposse \

--- a/test/terraform/Makefile
+++ b/test/terraform/Makefile
@@ -1,4 +1,4 @@
 TMP ?= /tmp
 TERRAFORM ?= $(BUILD_HARNESS_PATH)/vendor/terraform
-TERRAFORM_VERSION ?= 0.10.7
+TERRAFORM_VERSION ?= 0.14.11
 TERRAFORM_URL ?= https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(OS)_amd64.zip


### PR DESCRIPTION
## what
- Update `build-harness` 0.58.2 -> 0.58.4
- Update default Terraform version in `test/terraform/Makefile`: 0.10.7 -> 0.14.11

## why
- Support `aws eks get-token`
- Stay in sync with our modules