### PR TITLE
Configure bats tests for Terraform 1.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM cloudposse/build-harness:0.58.4
 
-RUN apk add --update --no-cache go bats vert@cloudposse terraform-config-inspect@cloudposse \
+RUN apk add --update --no-cache go bats vert@cloudposse \
+  terraform-config-inspect@cloudposse terraform-docs@cloudposse \
   terraform-0.11@cloudposse terraform-0.12@cloudposse terraform-0.13@cloudposse \
   terraform-0.14@cloudposse terraform-0.15@cloudposse terraform-1@cloudposse
+
 
 COPY test/ /test/
 

--- a/test/terraform/get-modules.bats
+++ b/test/terraform/get-modules.bats
@@ -1,16 +1,14 @@
 load 'lib'
 
 function setup() {
-  export TF_CLI_ARGS_init="-get-plugins -backend=false -input=false"
   clean
 }
 
 function teardown() {
   clean
-  unset TF_CLI_ARGS_init
 }
 
 @test "check if terraform modules are valid" {
   skip_unless_terraform
-  terraform init
+  skip "Terraform no longer supports separate testing of module loading"
 }

--- a/test/terraform/get-plugins.bats
+++ b/test/terraform/get-plugins.bats
@@ -1,16 +1,14 @@
 load 'lib'
 
 function setup() {
-  export TF_CLI_ARGS_init="-get-plugins -backend=false -input=false"
   clean
 }
 
 function teardown() {
   clean
-  unset TF_CLI_ARGS_init
 }
 
 @test "check if terraform plugins are valid" {
   skip_unless_terraform
-  terraform init
+  skip "Terraform no longer supports separate testing of plugins"
 }

--- a/test/terraform/init.bats
+++ b/test/terraform/init.bats
@@ -1,16 +1,16 @@
 load 'lib'
 
 function setup() {
-  rm -rf .terraform
+  clean
 }
 
 function teardown() {
-  rm -rf .terraform
+  clean
 }
 
-@test "check if terraform init works" {
+@test "check if terraform init succeeds" {
   skip_unless_terraform
-  run terraform init
+  run terraform init -input=false
   log "$output"
   [ $status -eq 0 ]
 }

--- a/test/terraform/lib.bash
+++ b/test/terraform/lib.bash
@@ -34,7 +34,7 @@ function log() {
 }
 
 function clean() {
-  rm -rf .terraform
+  rm -rf .terraform .terraform.lock.hcl
 }
 
 function skip_unless_terraform() {


### PR DESCRIPTION
## what
- Configure bats tests for Terraform 1.x

## why
- Support current version of Terraform. Previously `bats` tests would fail under Terraform 1.x due to features/flags present on earlier versions being removed.