### PR TITLE
Run terraform validate in examples/complete

### DIFF
--- a/test/terraform/validate.bats
+++ b/test/terraform/validate.bats
@@ -16,12 +16,12 @@ function teardown() {
 @test "check if terraform code is valid" {
   skip_unless_terraform
   if [[ "`terraform version | head -1`" =~ 0\.11 ]]; then
-    run terraform validate -check-variables=false
+    run terraform validate -chdir=examples/complete -check-variables=false
     [ $status -eq 0 ]
     [ -z "$output" ]
   else
     export AWS_DEFAULT_REGION="us-east-2"
-    run terraform validate .
+    run terraform validate -chdir=examples/complete .
     log_on_error "$status" "$output"
   fi
 }


### PR DESCRIPTION
## what
- Run terraform validate in examples/complete

## why
- Allow test/bats to pass in terraform module that require aliased providers
- The providers are configured correctly in the complete example so the validation should run in the correct directory instead of the module repo root

## references
- Thanks to @alexjurkiewicz for pointing out that the validation could be run in examples
- Thanks to @lorengordon for pointing out this open ticket https://github.com/hashicorp/terraform/issues/28490
- Relevant modules
  - https://github.com/cloudposse/terraform-aws-macie/
  - https://github.com/cloudposse/terraform-aws-firewall-manager/
