### PR TITLE
For validate, chdir if tf >= 0.14.0

### DIFF
--- a/test/terraform/provider-pinning.bats
+++ b/test/terraform/provider-pinning.bats
@@ -46,7 +46,7 @@ function teardown() {
   if vert "$(terraform-config-inspect --json . | jq -r '.required_core[]')" 0.12.25 >/devnull; then
     # Terraform version '$TERRAFORM_CORE_VERSION' less then 13. Skipping check for explicit provider source locations
     # ref: https://www.terraform.io/upgrade-guides/0-13.html#explicit-provider-source-locations
-    skip "Minimum Terraform version less then 0.12.26. Skipping check for explicit provider source locations"
+    skip "Minimum Terraform version less than 0.12.26. Skipping check for explicit provider source locations"
   else
     ## extract all required providers with sources into string with 'provider' | then 'source'
     terraform-config-inspect --json . | jq '.required_providers | to_entries[] | "  - \(.key)|\(.value.source)"' > $TMPFILE

--- a/test/terraform/validate.bats
+++ b/test/terraform/validate.bats
@@ -16,12 +16,21 @@ function teardown() {
 @test "check if terraform code is valid" {
   skip_unless_terraform
   if [[ "`terraform version | head -1`" =~ 0\.11 ]]; then
-    run terraform validate -chdir=examples/complete -check-variables=false
+    run terraform validate -check-variables=false
     [ $status -eq 0 ]
     [ -z "$output" ]
+  else if [[ ! vert "$(terraform-config-inspect --json . | jq -r '.required_core[]')" 0.14.0 ]]; then
+    export AWS_DEFAULT_REGION="us-east-2"
+    export TEST_HARNESS_VALIDATE_DIR=examples/complete
+    if [[ -d $TEST_HARNESS_VALIDATE_DIR ]]; then
+      run terraform validate -chdir=$TEST_HARNESS_VALIDATE_DIR .
+    else
+      run terraform validate .
+    fi
+    log_on_error "$status" "$output"
   else
     export AWS_DEFAULT_REGION="us-east-2"
-    run terraform validate -chdir=examples/complete .
+    run terraform validate .
     log_on_error "$status" "$output"
   fi
 }

--- a/test/terraform/validate.bats
+++ b/test/terraform/validate.bats
@@ -23,9 +23,9 @@ function teardown() {
     export AWS_DEFAULT_REGION="us-east-2"
     export TEST_HARNESS_VALIDATE_DIR=examples/complete
     if [[ -d $TEST_HARNESS_VALIDATE_DIR ]]; then
-      run terraform validate -chdir=$TEST_HARNESS_VALIDATE_DIR .
+      run terraform validate -chdir=$TEST_HARNESS_VALIDATE_DIR
     else
-      run terraform validate .
+      run terraform validate -chdir=.
     fi
     log_on_error "$status" "$output"
   else

--- a/test/terraform/validate.bats
+++ b/test/terraform/validate.bats
@@ -23,9 +23,9 @@ function teardown() {
     export AWS_DEFAULT_REGION="us-east-2"
     export TEST_HARNESS_VALIDATE_DIR=examples/complete
     if [[ -d $TEST_HARNESS_VALIDATE_DIR ]]; then
-      run terraform validate -chdir=$TEST_HARNESS_VALIDATE_DIR
+      run terraform -chdir=$TEST_HARNESS_VALIDATE_DIR validate
     else
-      run terraform validate -chdir=.
+      run terraform -chdir=. validate
     fi
     log_on_error "$status" "$output"
   else


### PR DESCRIPTION
## what
- Change directory only if terraform is greater than 0.14.0 and the directory exists

## why
- chdir was added in 0.14.0

## references
- vert is also used here to check if the tf version is lower than 0.12.26 https://github.com/cloudposse/test-harness/blob/5b9604311c9315c044cd06655e85f007cd0852c0/test/terraform/provider-pinning.bats#L46-L49
- Previous PR https://github.com/cloudposse/test-harness/pull/37
- test-harness is failing in this PR https://github.com/cloudposse/terraform-datadog-platform/pull/51

## commands

Tested this in the datadog platform module

```
⨠ make -C test/ clean init
⨠ cd test/.test-harness
⨠ git checkout terraform-validate-chdir
⨠ cd -
⨠ make -C test/ module
Running tests in  ../
1..11
ok 1 check if terraform is installed
ok 2 check if terraform code needs formatting
ok 3 # skip (Terraform no longer supports separate testing of module loading) check if terraform modules are valid
ok 4 check if terraform modules are properly pinned
ok 5 # skip (Terraform no longer supports separate testing of plugins) check if terraform plugins are valid
ok 6 check if terraform providers are properly pinned
ok 7 check if terraform providers have explicit source locations for TF =>0.13
ok 8 check if terraform code is valid
ok 9 check if terraform-docs is installed
ok 10 check if terraform inputs have descriptions
ok 11 check if terraform outputs have descriptions
```

In `0.14.x` and greater
```
⨠ terraform -chdir=examples/complete validate
Success! The configuration is valid.
```