### PR TITLE
Revert #37

### DIFF
--- a/test/terraform/provider-pinning.bats
+++ b/test/terraform/provider-pinning.bats
@@ -46,7 +46,7 @@ function teardown() {
   if vert "$(terraform-config-inspect --json . | jq -r '.required_core[]')" 0.12.25 >/devnull; then
     # Terraform version '$TERRAFORM_CORE_VERSION' less then 13. Skipping check for explicit provider source locations
     # ref: https://www.terraform.io/upgrade-guides/0-13.html#explicit-provider-source-locations
-    skip "Minimum Terraform version less then 0.12.26. Skipping check for explicit provider source locations"
+    skip "Minimum Terraform version less than 0.12.26. Skipping check for explicit provider source locations"
   else
     ## extract all required providers with sources into string with 'provider' | then 'source'
     terraform-config-inspect --json . | jq '.required_providers | to_entries[] | "  - \(.key)|\(.value.source)"' > $TMPFILE

--- a/test/terraform/validate.bats
+++ b/test/terraform/validate.bats
@@ -16,12 +16,12 @@ function teardown() {
 @test "check if terraform code is valid" {
   skip_unless_terraform
   if [[ "`terraform version | head -1`" =~ 0\.11 ]]; then
-    run terraform validate -chdir=examples/complete -check-variables=false
+    run terraform validate -check-variables=false
     [ $status -eq 0 ]
     [ -z "$output" ]
   else
     export AWS_DEFAULT_REGION="us-east-2"
-    run terraform validate -chdir=examples/complete .
+    run terraform validate .
     log_on_error "$status" "$output"
   fi
 }


### PR DESCRIPTION
## what
- Revert PR #37 

## why
- Introduced invalid Terraform command
- Broke contract that `bats` tests run against code in current directory