### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,7 @@
 name: "docker"
 on:
+  workflow_dispatch:
+
   pull_request:
     types: [opened, synchronize, reopened]
   release:
@@ -7,6 +9,7 @@ on:
     - created
   schedule:
     - cron:  '30 23 * * *'
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
 export DOCKER_BUILD_FLAGS =
 export README_DEPS ?= docs/targets.md
 
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 
 .DEFAULT_GOAL : build
 


### PR DESCRIPTION
## what and why 
Change all references to `git.io/build-harness` into `cloudposse.tools/build-harness`, since `git.io` redirects will stop working on April 29th, 2022.

## References
- DEV-143