### PR TITLE
Update github output syntax

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
         if [[ ${{ github.event_name }} == 'schedule' ]]; then
           TAGS="$TAGS,${{ github.repository }}:latest,${{ github.repository }}:nightly"
         fi
-        echo ::set-output name=tags::${TAGS}
+        echo "tags=${TAGS}" >> $GITHUB_OUTPUT
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to DockerHub


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/