### PR TITLE
Update workflows to node20

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -16,6 +16,7 @@ version-resolver:
       - 'bugfix'
       - 'bug'
       - 'hotfix'
+      - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,15 +5,11 @@ on:
     branches:
     - master
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
-  semver:
-    runs-on: ubuntu-latest
-    steps:
-    # Drafts your next Release notes as Pull Requests are merged into "master"
-    - uses: release-drafter/release-drafter@v5
-      with:
-        publish: true
-        prerelease: false
-        config-name: auto-release.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+  release:
+    uses:  cloudposse/github-actions-workflows/.github/workflows/controller-release.yml@main
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Prepare tags for Docker image
       if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule'
       id: prepare
@@ -37,16 +37,16 @@ jobs:
         fi
         echo "tags=${TAGS}" >> $GITHUB_OUTPUT
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
     - name: Login to DockerHub
       if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     - name: "Build and push docker image to DockerHub"
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' }}
         tags: ${{ steps.prepare.outputs.tags }}


### PR DESCRIPTION
## what

- Update workflows to use `node20` versions of actions
- Update auto-release to use shared controller-release workflow

## why

- Previously using `node12` actions, which are no longer supported

