### PR TITLE
add test/run/in-docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export DOCKER_TAG ?= latest
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
 export DOCKER_BUILD_FLAGS =
 export README_DEPS ?= docs/targets.md
+export DOCKER_DEFAULT_PLATFORM ?= linux/amd64
 
 -include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 
@@ -12,4 +13,3 @@ export README_DEPS ?= docs/targets.md
 ## Build docker image
 build:
 	@make --no-print-directory docker/build
-

--- a/test/run/Makefile
+++ b/test/run/Makefile
@@ -24,7 +24,7 @@ in-docker:
 		-v $(TEST_HARNESS_LOCAL_ROOT):/module/ \
 		$(DOCKER_IMAGE_NAME) -C /module/$(TEST_HARNESS_WORKING_DIR) $(TEST_HARNESS_TARGET)
 
-# Example for Makefile target to run with terratest (Makefile in ./test/src_
+# Example for Makefile target to run with terratest (Makefile in ./test/src)
 #
 # test: init
 #	go mod download

--- a/test/run/Makefile
+++ b/test/run/Makefile
@@ -1,0 +1,35 @@
+TEST_HARNESS_CONTAINER_NAME ?= test-harness
+TEST_HARNESS_LOCAL_ROOT ?= $(shell pwd)
+TEST_HARNESS_WORKING_DIR ?= .
+TEST_HARNESS_TARGET ?= test
+TEST_HARNESS_DEFAULT_PATH ?= /go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+DOCKER ?= DOCKER
+DOCKER_ORG ?= cloudposse
+DOCKER_IMAGE ?= $(DOCKER_ORG)/test-harness
+DOCKER_TAG ?= latest
+DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
+
+.PHONY: in-docker
+
+## Run a containerized test-harness module
+in-docker: export DOCKER_DEFAULT_PLATFORM ?= linux/amd64
+in-docker: TEST_HARNESS_TERRAFORM_VERSION ?= $(shell curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version' | cut -d. -f1)
+in-docker: TEST_HARNESS_TERRAFORM_PATH ?= /usr/local/terraform/$(TEST_HARNESS_TERRAFORM_VERSION)/bin
+in-docker:
+	"$(DOCKER)" run --name $(TEST_HARNESS_CONTAINER_NAME) --rm -it \
+		-e GITHUB_TOKEN \
+		-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_ENDPOINT_URL \
+		-e PATH="$(TEST_HARNESS_PATH):$(TEST_HARNESS_TERRAFORM_PATH):$(TEST_HARNESS_DEFAULT_PATH)" \
+		-v $(TEST_HARNESS_LOCAL_ROOT):/module/ \
+		$(DOCKER_IMAGE_NAME) -C /module/$(TEST_HARNESS_WORKING_DIR) $(TEST_HARNESS_TARGET)
+
+# Example for Makefile target to run with terratest (Makefile in ./test/src_
+#
+# test: init
+#	go mod download
+#	go test -v -timeout 60m
+#
+# test/docker: TEST_HARNESS_LOCAL_ROOT = $(CURDIR)/../../
+# test/docker: TEST_HARNESS_WORKING_DIR = test/src
+# test/docker: test/run/in-docker


### PR DESCRIPTION
## what

- add test/run/in-docker target
- adds AWS_ENDPOINT_URL

## why

- use generic target in test harness, vs specific per repositpry
- allows for bulk update of eg env vars to pass on
- still allowing repo sepcific setup
- AWS_ENDPOINT_URL allows for injection for eg localstacl

## notes

- not fully clear how the full harness structure works, esp regarding variable inheritance/overrides. 
- likely we can move the two prefixed vars to the top of the makefile
- there is already a terraform_version var with a predefined value in the test/terraform section, that one is different from the default in the test/src (in the calling repo), hence opted for a new var.