### PR TITLE
Disable default terraform reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apk add --update --no-cache go bats vert@cloudposse \
   terraform-0.14@cloudposse terraform-0.15@cloudposse terraform-1@cloudposse \
 	opentofu@community
 
+RUN update-alternatives --remove-all terraform
+
 
 COPY test/ /test/
 


### PR DESCRIPTION
## what
* Disable default terraform reference

## why
* Allow to use OpenToFu for terratest use `Option 1` of migration guide to use OpenToFu
```
Migration Guide
Switching to tofu:

* Install OpenTofu cli https://github.com/opentofu/opentofu
* Apply one of:
    Option 1: Remove terraform binary from PATH
    Option 2: use [TerraformBinary config](https://github.com/gruntwork-io/terratest/blob/master/modules/terraform/options.go#L41) to specify tofu executable
```

## references
* https://github.com/gruntwork-io/terratest/releases/tag/v0.46.0