### PR TITLE
Bats fixes

### DIFF
--- a/test/terraform/module-pinning.bats
+++ b/test/terraform/module-pinning.bats
@@ -17,7 +17,8 @@ function teardown() {
   skip_unless_terraform
   ## Extract all module calls (except submodules in ./modules/) into string with source then | then version (if version parameter exists)
   ## Add || true at the end because a pipe failure just means this module has no calls to other modules
-  terraform-config-inspect --json . | jq '.module_calls[] | "\(.source)|\(.version)"' | grep -v -F '"./modules' > $TMPFILE || true
+  ## The  grep -v '^"\.\./' is to exclude modules in the same repo (e.g. "../stack") from the check
+  terraform-config-inspect --json . | jq '.module_calls[] | "\(.source)|\(.version)"' | grep -v -F '"./modules' | grep -v '^"\.\./' > $TMPFILE || true
   ## check if module url have version in tags or if version pinned with 'version' parameter for Terraform Registry notation
   ## check diff between terraform-config-inspect output and regexp check to see if all cases are passing checks
   fail=$(grep -vE '^(\".*?tags\/[0-9]+\.[0-9]+.*\|null\"\s?|\".*?\|[0-9]+\.[0-9]+.*\"\s?)+' $TMPFILE) || true

--- a/test/terraform/provider-pinning.bats
+++ b/test/terraform/provider-pinning.bats
@@ -28,7 +28,8 @@ function teardown() {
   fi
 
   ## extract all required providers into string with 'provider' | then version constraint
-  terraform-config-inspect --json . | jq '.required_providers | to_entries[] | "  - \(.key)|\(.value.version_constraints[])"' > $TMPFILE
+  ## Note that when using the builtin "terraform" provider, version_constraints is always null 
+  terraform-config-inspect --json . | jq '.required_providers | to_entries[] | select(.key != "terraform") | "  - \(.key)|\(.value.version_constraints[])"' > $TMPFILE
   ## Ensure provider version constraint is '>='
   fail=$(grep -v '|>=' $TMPFILE) || true
   if [[ -n "$fail" ]]; then
@@ -49,7 +50,8 @@ function teardown() {
     skip "Minimum Terraform version less than 0.12.26. Skipping check for explicit provider source locations"
   else
     ## extract all required providers with sources into string with 'provider' | then 'source'
-    terraform-config-inspect --json . | jq '.required_providers | to_entries[] | "  - \(.key)|\(.value.source)"' > $TMPFILE
+    ## Note that when using the builtin "terraform" provider, source is always null
+    terraform-config-inspect --json . | jq '.required_providers | to_entries[] | select(.key != "terraform") | "  - \(.key)|\(.value.source)"' > $TMPFILE
     ## check if provider source exists for every provider
     fail=$(grep -F '|null' $TMPFILE) || true
     if [[ -n "$fail" ]]; then


### PR DESCRIPTION
## what

- Do not require module version for local modules
- Do not require provider version or source for built-in provider

## why
* local modules do not have a version number 
* Built-in `terraform` provider does not have version or source
