### PR TITLE
Use .github repo for auto-release workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   release:
-    uses:  cloudposse/github-actions-workflows/.github/workflows/controller-release.yml@main
+    uses:  cloudposse/.github/.github/workflows/shared-auto-release.yml@main
 


### PR DESCRIPTION
## what
* Use .github repo for auto-release workflows

## why
* `cloudposse/github-actions-workflows` repo archived