### PR TITLE
Module pinning - remove tags

### DIFF
--- a/test/terraform/module-pinning.bats
+++ b/test/terraform/module-pinning.bats
@@ -21,7 +21,7 @@ function teardown() {
   terraform-config-inspect --json . | jq '.module_calls[] | "\(.source)|\(.version)"' | grep -v -F '"./modules' | grep -v '^"\.\./' > $TMPFILE || true
   ## check if module url have version in tags or if version pinned with 'version' parameter for Terraform Registry notation
   ## check diff between terraform-config-inspect output and regexp check to see if all cases are passing checks
-  fail=$(grep -vE '^(\".*?tags\/v?[0-9]+\.[0-9]+.*\|null\"\s?|\".*?\|v?[0-9]+\.[0-9]+.*\"\s?)+' $TMPFILE) || true
+  fail=$(grep -vE '^(\".*?v?[0-9]+\.[0-9]+.*\|null\"\s?|\".*?\|v?[0-9]+\.[0-9]+.*\"\s?)+' $TMPFILE) || true
   if [[ -n "$fail" ]]; then
     output_msg=$'\nCloud Posse requires all module sources to be pinned to a specific version, e.g. 0.9.1 or v0.9.1\n'
     output_msg+=$'Please fix these module sources:\n'


### PR DESCRIPTION
## what
* Bats module pinning test removed requirements of  `tags/` prefix in source git ref

## why
* Terraform handles incorrectly git paths which have slashes in ref parameter

## references
* https://github.com/hashicorp/go-getter/issues/469
* https://github.com/cloudposse-terraform-components/aws-datadog-credentials/pull/33