### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Prepare tags for Docker image
       if: (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
       id: prepare
@@ -39,16 +39,16 @@ jobs:
         fi
         echo "tags=${TAGS}" >> $GITHUB_OUTPUT
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
     - name: Login to DockerHub
       if: (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-      uses: docker/login-action@v3
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     - name: "Build and push docker image to DockerHub"
       id: docker_build
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         push: ${{ (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
         tags: ${{ steps.prepare.outputs.tags }}


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `docker/setup-buildx-action@v3` → `@bb05f3f5...` `# v4.2.0`
  * `docker/login-action@v3` → `@dbcb8138...` `# v4.6.0`
  * `docker/build-push-action@v5` → `@53b7df96...` `# v7.3.0`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
